### PR TITLE
Add Google Cloud PubSub Exporter to Splunk OTEL Collector

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -112,21 +112,22 @@ The distribution offers support for the following components.
 
 <div>
 
-| Exporters                                                                                                                   | Stability        |
-|:----------------------------------------------------------------------------------------------------------------------------|:-----------------|
-| [awss3](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)                 | [alpha]          |
-| [debug](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter)                         | [in development] |
-| [file](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter)                   | [alpha]          |
-| [kafka](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter)                 | [beta]           |
-| [loadbalancing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter) | [beta]           |
-| [logging](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter)                     | [deprecated]     |
-| [nop](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/nopexporter)                             | [beta]           |
-| [otlp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter)                           | [stable]         |
-| [otlphttp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)                   | [stable]         |
-| [pulsar](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/pulsarexporter)               | [alpha]          |
-| [sapm](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter)                   | [beta]           |
-| [signalfx](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter)           | [beta]           |
-| [splunk_hec](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter)        | [beta]           |
+| Exporters                                                                                                               		| Stability        |
+|:--------------------------------------------------------------------------------------------------------------------------------------|:-----------------|
+| [awss3](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)                		| [alpha]          |
+| [googlecloudpubsub](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudpubsubexporter)   | [beta] 
+| [debug](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter)                         		| [in development] |
+| [file](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter)                   		| [alpha]          |
+| [kafka](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter)                 		| [beta]           |
+| [loadbalancing](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter) 		| [beta]           |
+| [logging](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter)                     		| [deprecated]     |
+| [nop](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/nopexporter)                             		| [beta]           |
+| [otlp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter)                           		| [stable]         |
+| [otlphttp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)                   		| [stable]         |
+| [pulsar](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/pulsarexporter)               		| [alpha]          |
+| [sapm](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter)                   		| [beta]           |
+| [signalfx](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter)           		| [beta]           |
+| [splunk_hec](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter)        		| [beta]           |
 
 </div>
 

--- a/go.mod
+++ b/go.mod
@@ -326,6 +326,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/open-telemetry/opamp-go v0.19.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.125.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.125.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.125.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.125.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1331,6 +1331,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.125.0/go.mod h1:78krVMLf0F+fXpFJPJgu62sLucRIyYT/Vfdy/v1piZQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.125.0 h1:Hs7tJvZ4OljBqndN+D/ZxIcIA9Zt14oSAZmHINrnS/s=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.125.0/go.mod h1:dt3hAfER9HUAwMznSOdLufj+i8qAn2/SUkTlj52tXqk=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.125.0 h1:lNF7pxIxHWxQzP7k/hb39O14fwCaEbRChiWpBOWw7+k=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.125.0/go.mod h1:XgUhG5TE6IkmtkOe/56lFdZ8ZsHpAxG1pEbvTcP6foI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.125.0 h1:iwG8Tt1jCfj30s3tNQMqfALRGgx7sdrFptRFwa/oqjE=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.125.0/go.mod h1:Ue2rr6BmxHZLqztt2uVVQk5Pa0WEYNVm+z/xpRXU5tQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.125.0 h1:CoRatnykS9bmnxektINmYxViJDgzKW3jLqNEHfD3cMw=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
@@ -244,6 +245,7 @@ func Get() (otelcol.Factories, error) {
 
 	exporters, err := otelcol.MakeFactoryMap(
 		awss3exporter.NewFactory(),
+		googlecloudpubsubexporter.NewFactory(),
 		debugexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		kafkaexporter.NewFactory(),

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -137,6 +137,7 @@ func TestDefaultComponents(t *testing.T) {
 	}
 	expectedExporters := []string{
 		"awss3",
+		"googlecloudpubsub",
 		"debug",
 		"file",
 		"kafka",


### PR DESCRIPTION
**Description:**

Add Google Cloud PubSub Exporter to Splunk OTEL Collector

**Link to Splunk idea:**
https://ideas.splunk.com/ideas/SFXIMMID-I-743